### PR TITLE
ADD: users.view

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -1,0 +1,25 @@
+import jwt
+
+from functools       import wraps
+from django.http     import JsonResponse
+from config.settings import SECRET_KEY, ALGORITHM
+
+from users.models import User
+
+def login_decorator(func):
+    @wraps(func)
+    def wrapper(self, request, *args, **kwargs):
+        try:
+            access_token = request.headers.get('Authorization', None)
+            payload      = jwt.decode(access_token, SECRET_KEY, algorithms=ALGORITHM)
+            request.user = User.objects.get(id=payload['id'])
+
+        except jwt.exceptions.DecodeError:
+            return JsonResponse({'message' : 'INVALID_TOKEN'}, status = 401) 
+
+        except User.DoesNotExist:
+            return JsonResponse({'message' : 'INVALID_USER'}, status = 401)
+
+        return func(self, request, *args, **kwargs)
+
+    return wrapper

--- a/users/views.py
+++ b/users/views.py
@@ -1,3 +1,74 @@
-from django.shortcuts import render
+import json
+import re
+import bcrypt
+import jwt
 
-# Create your views here.
+from django.http     import JsonResponse
+from django.views    import View
+from django.db.utils import IntegrityError
+from django.db       import transaction
+
+from config.settings import SECRET_KEY, ALGORITHM
+from users.models    import User
+
+
+class SignUpView(View):
+    @transaction.atomic()
+    def post(self, request):
+        try:
+            data     = json.loads(request.body)
+            name     = data['name']
+            password = data['password']
+
+            # 유저가 사용하고자 하는 아이디를 정규식을 통해 검증
+            # 알파벳으로 시작하며 알파벳, 숫자, 일부 특수문자('-', '_', '.')을 사용한 8~15자 사용가능
+            if not re.match('^[a-zA-Z][a-zA-Z0-9-_.]{8,15}$'):
+                return JsonResponse({"MESSAGE" : "INVALD_NAME"}, status=400)
+
+            # 유저가 사용하고자 하는 비밀번호를 정규식으로 검증
+            # 알파벳, 숫자, 일부 특수문자를 사용한 8~20자 사용가능
+            if not re.match("^[a-zA-Z0-9!@#$%^&*()\-_=+?~`]{8,20}$", password):
+                return JsonResponse({"MESSAGE" : "INVALD_PASSWORD"}, status=400)
+
+            # 유저가 사용하고자 하는 아이디가 이미 존재할 경우 에러 반환
+            if User.objects.filter(name=name).exists():
+                return JsonResponse({"MESSAGE" : "NAME_EXISTS"}, status=400)
+
+            # 유저가 입력한 비밀번호를 bcrypt를 활용해 암호화
+            hashed_password = bcrypt.hashpw(
+                password.encode("utf-8"), bcrypt.gensalt()
+            ).decode("utf-8")
+
+            # 유저가 입력한 아이디, 암호화 된 비밀번호, 닉네임을 DB에 입력
+            # 초기 닉네임은 유저의 아이디와 동일
+            User.objects.create(name = name, password = hashed_password, nickname = name)
+            return JsonResponse({'MESSAGE' : 'SUCCESS'}, status=201)
+
+        # 입력값(아이디 혹은 비밀번호) 중 하나라도 빈 칸으로 들어오면 에러 반환
+        except KeyError:
+            return JsonResponse({'MESSAGE' : 'KEY_ERROR'}, status=400)
+
+
+class SignInView(View):
+    def post(self, request):
+        try:
+            data     = json.loads(request.body)
+            name     = data['name']
+            password = data['password']
+            user     = User.objects.get(name=name)
+
+            # 로그인하게 위해 입력한 비밀번호를 bcrypt를 통해 암화화하며 해당 비밀번호가 암호화 되어 저장되어 있는 비밀번호와 불일치 시 에러 반환
+            if not bcrypt.checkpw(password.encode('utf-8'), user.password.encode('utf-8')):
+                return JsonResponse({'MESSAGE':'INVALID_USER'}, status=401)
+
+            # 아이디와 비밀번호가 알맞게 입력된다면 DB 상 입력되어 있는 해당 유저의 ID를 jwt로 복호화 해 생성
+            access_token = jwt.encode(user.id, SECRET_KEY, algorithm = ALGORITHM)
+            # 후에 프론트 사이드로 토큰과 status_code(200)를 반환해 로그인에 성공했음을 알림
+            return JsonResponse({'MESSAGE':'SUCCESS', 'ACCESS_TOKEN': access_token}, status=200)
+
+        # 입력값(아이디 혹은 비밀번호) 중 하나라도 빈 칸으로 들어오면 에러 반환
+        except KeyError:
+            return JsonResponse({'MESSAGE':'KEY_ERROR'}, status=400)
+        # 유저가 입력한 아이디가 존재하지 않을 경우 에러 반환
+        except User.DoesNotExist:
+            return JsonResponse({'MESSAGE':'USER_DOES_NOT_EXIST'}, status=404)


### PR DESCRIPTION
## :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- 유저 회원가입 및 로그인 기능 구현

<br />

## :: 구현 사항 설명
1. 유저 회원가입 API 구현
- 회원가입 시 아이디, 비밀번호를 요구하며 둘 중 하나라도 입력되지 않았을 경우 에러 반환
- 유저가 사용하고자 하는 아이디는 알파벳으로 시작하며 알파벳, 숫자, 일부 특수문자('-', '_', '.')을 사용한 8~15자를,
비밀번호는 알파벳, 숫자, 일부 특수문자를 사용한 8~20자를 사용하고자 하였으며
- 정규식을 통해 검증함. 만약 프론트사이드도 존재했다면 백-프론트 이중 검증을 진행
- 두 조건 모두 만족한다면 `bcrypt`를 통해 유저의 비밀번호를 암호화 하여 DB에 저장
- 유저가 사용하고자 하는 아이디가 이미 존재할 경우를 가정해 
서버단에서 미리 `User.objects.filter(name=name).exists()` 를 통해 존재 유무를 판별, 중복 된 아이디라면 에러 반환

2. 유저 로그인 API 구현
- 로그인 시 아이디, 비밀번호를 요구하며 둘 중 하나라도 입력되지 않았을 경우 에러 반환
- 유저가 입력한 아이디가 DB에 존재하지 않을 경우 에러 반환
- 유저가 로그인 하기 위해 입력한 비밀번호와 DB에 저장 된 비밀번호를 같은 알고리즘을 통해 암호화 해 비교 후 일치하지 않을 경우 에러 반환
- 입력한 아이디와 비밀번호 모두 일치할 경우 `jwt`를 통해 생성한 토큰과 로그인 성공 status_code를 프론트 사이드로 반환
- 후에 로그인 상태를 검증하기 위한 로그인 데코레이터 작성